### PR TITLE
http - fixed runtime index out of range

### DIFF
--- a/http.go
+++ b/http.go
@@ -117,6 +117,9 @@ func (ft *Future) call(state string, callback RequestCallback) *Future {
 				panic(fmt.Sprintf("Response \"%v\" cannot be parsed to type %s. Error %v", sdata, dparam, err.Error()))
 			}
 		}
+		if len(in) < 2 {
+			panic("Can't map response to callback arguments. Should be func(data interface{}, status int)")
+		}
 		in[0] = d.Elem()
 		in[1] = reflect.ValueOf(status)
 		reflect.ValueOf(callback).Call(in)


### PR DESCRIPTION
Hi,

I fell over this issue while replicating the angularjs tutorial in gopherjs.
(You can find my fork of the tut [here](https://github.com/cryptix/GopherAngularTutorial) if you are interested but I'm not done yet)

This gives you a nicer error message when you don't supply enough arguments in your callback.
So far you only get `runtime error: index out of range` which doesn't help much.

I also thought about turning `RequestCallback` into something like `func(interface{}, int)` instead of just `interface{}` but i'm to new to gopherjs and it would break other usages of the callback I think.
