### PR TITLE
Use js.Any instead of interface{}.

### DIFF
--- a/angularjs.go
+++ b/angularjs.go
@@ -26,7 +26,7 @@ func (e *JQueryElement) Prop(name string) js.Object {
 	return e.Call("prop", name)
 }
 
-func (e *JQueryElement) SetProp(name, value interface{}) {
+func (e *JQueryElement) SetProp(name, value js.Any) {
 	e.Call("prop", name, value)
 }
 
@@ -40,7 +40,7 @@ func (e *JQueryElement) Val() js.Object {
 	return e.Call("val")
 }
 
-func (e *JQueryElement) SetVal(value interface{}) {
+func (e *JQueryElement) SetVal(value js.Any) {
 	e.Call("val", value)
 }
 


### PR DESCRIPTION
Related to change in gopherjs/gopherjs@1dae489721d66fc0b05af4976b0ef45cbd564c07.

This fixes an issue upstream when trying to build `playground.go`. The following snippet:

```Go
box := angularjs.ElementById("output")
box.SetProp("scrollTop", box.Prop("scrollHeight"))
```

Produces an error:

```
playground.go:293:30: can't convert js.Object/js.Any to other interface type
```

This PR fixes that problem and allows `playground.go` to build successfully.

I've applied the change to `SetVal` also because it looks similar, but that is untested.

Please review because I am not yet very familiar with `js.Any`.